### PR TITLE
Switch to using `pull_request_target`

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,13 +1,15 @@
 name: Run Milo Bot Release Email
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, edited, closed]
+  pull_request_target:
+    types:
+      - closed
     branches:
       - main
 
 jobs:
   action:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
This is to allow PRs based on forks to still be able to run this action.